### PR TITLE
Fix processing for dictionary node without 'nodesByName' attribute

### DIFF
--- a/src/ProcessSchema/SymfonyConfig/process-schema.php
+++ b/src/ProcessSchema/SymfonyConfig/process-schema.php
@@ -31,7 +31,7 @@ function configureNode(NodeParentInterface $configNode, Node $node): void {
         }
 
         /** @var ArrayNodeDefinition $configNode */
-        foreach ($node->attribute('nodesByName', []) as $name => $childConfigNode) {
+        foreach ($node->attribute('nodesByName') ?? [] as $name => $childConfigNode) {
             configureNode($resNode->children(), $childConfigNode->withAddedAttributes(['name' => $name]));
         }
     } else if ($node->type() === "string" || $node->type() === "mixed") {


### PR DESCRIPTION
There is no second argument for default value in `attribute()`